### PR TITLE
Check if URL is external instead of relative

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   },
   "dependencies": {
     "babel-runtime": "^6.26.0",
-    "is-relative-url": "^2.0.0",
+    "is-url-external": "^1.0.3",
     "unist-util-find": "^1.0.1",
     "unist-util-visit": "^1.1.3"
   },

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,6 @@
 const visit = require(`unist-util-visit`)
 const find = require(`unist-util-find`)
-const isRelativeUrl = require(`is-relative-url`)
+const isUrlExternal = require(`is-url-external`)
 
 const defaultTarget = "_blank"
 const defaultRel = "nofollow noopener noreferrer"
@@ -8,13 +8,13 @@ const defaultRel = "nofollow noopener noreferrer"
 module.exports = ({ markdownAST }, options = {}) => {
 
   const visitor = (link, url) => {
-    if(!isRelativeUrl(url)) {
+    if (isUrlExternal(url) || url.startsWith('mailto:')) {
       link.data = {
         hProperties: {}
       }
-      if(options.target !== null)
+      if (options.target !== null)
         link.data.hProperties.target = options.target || defaultTarget;
-      if(options.rel !== null)
+      if (options.rel !== null)
         link.data.hProperties.rel = options.rel || defaultRel;
     }
   }


### PR DESCRIPTION
Hi,

I'm using this plugin on a site and I was thinking if we could check for external links based on `hostname` instead of relative path.

Plus, it doesn't catch `mailto` links at the moment.

What do you think?

Thanks for taking the time :)